### PR TITLE
Cannot locate tasks that match ':composeApp:testClasses' ...回避のワークアラウンド追加

### DIFF
--- a/WeatherReport/composeApp/build.gradle.kts
+++ b/WeatherReport/composeApp/build.gradle.kts
@@ -77,3 +77,9 @@ android {
     }
 }
 
+/**
+ * Cannot locate tasks that match ':composeApp:testClasses'
+ * as task 'testClasses' not found in project ':composeApp'回避のワークアラウンド
+ * https://github.com/robolectric/robolectric/issues/1802
+ */
+tasks.register("testClasses"){}


### PR DESCRIPTION
## 内容

- Cannot locate tasks that match ':composeApp:testClasses' as task 'testClasses' not found in project ':composeApp'回避のワークアラウンド追加
  - https://github.com/robolectric/robolectric/issues/1802
  - KMP Wizardで生成したプロジェクトだと発生するらしい。原因は不明。