### PR TITLE
moko-mvvmからlifecycle-viewmodel-composeに移行

### DIFF
--- a/WeatherReport/composeApp/build.gradle.kts
+++ b/WeatherReport/composeApp/build.gradle.kts
@@ -60,7 +60,7 @@ kotlin {
             implementation(libs.voyager.tabNavigator)
             implementation(libs.voyager.transitions)
             implementation(libs.orbit.mvi.core)
-            implementation(libs.moko.mvvm.core)
+            implementation(libs.androidx.lifecycle.viewmodel)
             implementation(libs.kamel.image)
             implementation(libs.lavmee.constraintlayout)
         }

--- a/WeatherReport/composeApp/src/androidMain/kotlin/Platform.android.kt
+++ b/WeatherReport/composeApp/src/androidMain/kotlin/Platform.android.kt
@@ -1,5 +1,5 @@
 import android.os.Build
-import dev.icerock.moko.mvvm.viewmodel.ViewModel
+import androidx.lifecycle.ViewModel
 import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.core.definition.Definition
 import org.koin.core.definition.KoinDefinition

--- a/WeatherReport/composeApp/src/commonMain/kotlin/Platform.kt
+++ b/WeatherReport/composeApp/src/commonMain/kotlin/Platform.kt
@@ -1,4 +1,4 @@
-import dev.icerock.moko.mvvm.viewmodel.ViewModel
+import androidx.lifecycle.ViewModel
 import org.koin.core.definition.Definition
 import org.koin.core.definition.KoinDefinition
 import org.koin.core.module.Module

--- a/WeatherReport/composeApp/src/iosMain/kotlin/Platform.ios.kt
+++ b/WeatherReport/composeApp/src/iosMain/kotlin/Platform.ios.kt
@@ -1,4 +1,4 @@
-import dev.icerock.moko.mvvm.viewmodel.ViewModel
+import androidx.lifecycle.ViewModel
 import org.koin.core.definition.Definition
 import org.koin.core.definition.KoinDefinition
 import org.koin.core.module.Module

--- a/WeatherReport/gradle/libs.versions.toml
+++ b/WeatherReport/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ androidx-core-ktx = "1.12.0"
 androidx-espresso-core = "3.5.1"
 androidx-material = "1.11.0"
 androidx-test-junit = "1.1.5"
+androidx-lifecycle = "2.8.0-alpha04"
 buildkonfigGradlePlugin = "0.15.1"
 compose = "1.6.2"
 compose-plugin = "1.6.0"
@@ -22,7 +23,6 @@ ksp = "1.9.22-1.0.17"
 koin = "3.5.3"
 voyager = "1.0.0"
 orbit-mvi = "6.1.1"
-moko = "0.16.1"
 kamel = "0.9.3"
 lavmee = "0.3.1"
 
@@ -37,6 +37,7 @@ androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version
 androidx-material = { group = "com.google.android.material", name = "material", version.ref = "androidx-material" }
 androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "androidx-constraintlayout" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activityCompose" }
+androidx-lifecycle-viewmodel = { module = "androidx.lifecycle:lifecycle-viewmodel", version.ref = "androidx-lifecycle" }
 compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "compose" }
 compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "compose" }
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
@@ -58,7 +59,6 @@ voyager-bottomSheetNavigator = { module = "cafe.adriel.voyager:voyager-bottom-sh
 voyager-tabNavigator = { module = "cafe.adriel.voyager:voyager-tab-navigator", version.ref = "voyager" }
 voyager-transitions = { module = "cafe.adriel.voyager:voyager-transitions", version.ref = "voyager" }
 orbit-mvi-core = { module = "org.orbit-mvi:orbit-core", version.ref = "orbit-mvi" }
-moko-mvvm-core = { module = "dev.icerock.moko:mvvm-core", version.ref = "moko" }
 kamel-image = { module = "media.kamel:kamel-image", version.ref = "kamel" }
 lavmee-constraintlayout = { module = "tech.annexflow.compose:constraintlayout-compose-multiplatform", version.ref = "lavmee" }
 


### PR DESCRIPTION
viewmodelがKMPに対応したため