### PR TITLE
位置情報のpermissionをリクエストできるよう変更

### DIFF
--- a/WeatherReport/composeApp/build.gradle.kts
+++ b/WeatherReport/composeApp/build.gradle.kts
@@ -63,6 +63,7 @@ kotlin {
             implementation(libs.moko.mvvm.core)
             implementation(libs.kamel.image)
             implementation(libs.lavmee.constraintlayout)
+            implementation(libs.accompanist.permissions)
         }
         commonTest.dependencies {
             implementation(libs.koin.test)

--- a/WeatherReport/composeApp/src/androidMain/AndroidManifest.xml
+++ b/WeatherReport/composeApp/src/androidMain/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 
     <application
         android:allowBackup="true"

--- a/WeatherReport/composeApp/src/androidMain/kotlin/LocationView.android.kt
+++ b/WeatherReport/composeApp/src/androidMain/kotlin/LocationView.android.kt
@@ -1,0 +1,25 @@
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Modifier
+import com.google.accompanist.permissions.ExperimentalPermissionsApi
+import com.google.accompanist.permissions.rememberMultiplePermissionsState
+
+@OptIn(ExperimentalPermissionsApi::class)
+@Composable
+actual fun LocationView(
+    modifier: Modifier
+) {
+    val locationPermissionState = rememberMultiplePermissionsState(
+        listOf(
+            android.Manifest.permission.ACCESS_FINE_LOCATION,
+            android.Manifest.permission.ACCESS_COARSE_LOCATION
+        )
+    )
+    if (locationPermissionState.allPermissionsGranted) {
+        // 何もしない
+    } else {
+        LaunchedEffect(Unit) {
+            locationPermissionState.launchMultiplePermissionRequest()
+        }
+    }
+}

--- a/WeatherReport/composeApp/src/commonMain/kotlin/App.kt
+++ b/WeatherReport/composeApp/src/commonMain/kotlin/App.kt
@@ -125,6 +125,8 @@ object SecondTab : Tab, KoinComponent {
         val state = viewModel.container.stateFlow.collectAsState().value
         Logger.d { "Total: ${state.total}" }
 
+        LocationView(modifier = Modifier)
+
         Column(
             modifier = Modifier.fillMaxSize()
         ) {

--- a/WeatherReport/composeApp/src/commonMain/kotlin/LocationView.kt
+++ b/WeatherReport/composeApp/src/commonMain/kotlin/LocationView.kt
@@ -1,0 +1,7 @@
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+@Composable
+expect fun LocationView(
+    modifier: Modifier
+)

--- a/WeatherReport/composeApp/src/iosMain/kotlin/LocationView.ios.kt
+++ b/WeatherReport/composeApp/src/iosMain/kotlin/LocationView.ios.kt
@@ -1,0 +1,27 @@
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Modifier
+import platform.CoreLocation.CLLocationManager
+import platform.CoreLocation.kCLAuthorizationStatusAuthorizedAlways
+import platform.CoreLocation.kCLAuthorizationStatusAuthorizedWhenInUse
+import platform.CoreLocation.kCLAuthorizationStatusRestricted
+
+@Composable
+actual fun LocationView(
+    modifier: Modifier
+) {
+    val locationManager = CLLocationManager()
+    LaunchedEffect(Unit) {
+        when (locationManager.authorizationStatus()) {
+            kCLAuthorizationStatusAuthorizedAlways,
+            kCLAuthorizationStatusAuthorizedWhenInUse,
+            kCLAuthorizationStatusRestricted -> {
+                // 何もしない
+            }
+
+            else -> {
+                locationManager.requestWhenInUseAuthorization()
+            }
+        }
+    }
+}

--- a/WeatherReport/gradle/libs.versions.toml
+++ b/WeatherReport/gradle/libs.versions.toml
@@ -25,6 +25,7 @@ orbit-mvi = "6.1.1"
 moko = "0.16.1"
 kamel = "0.9.3"
 lavmee = "0.3.1"
+accompanist-permissions = "0.35.0-alpha"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
@@ -61,6 +62,7 @@ orbit-mvi-core = { module = "org.orbit-mvi:orbit-core", version.ref = "orbit-mvi
 moko-mvvm-core = { module = "dev.icerock.moko:mvvm-core", version.ref = "moko" }
 kamel-image = { module = "media.kamel:kamel-image", version.ref = "kamel" }
 lavmee-constraintlayout = { module = "tech.annexflow.compose:constraintlayout-compose-multiplatform", version.ref = "lavmee" }
+accompanist-permissions = { module = "com.google.accompanist:accompanist-permissions", version.ref = "accompanist-permissions" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }

--- a/WeatherReport/iosApp/iosApp/Info.plist
+++ b/WeatherReport/iosApp/iosApp/Info.plist
@@ -46,5 +46,7 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>NSLocationWhenInUseUsageDescription</key>
+    <string>Our app uses location for tracking user's location while on the weather track.</string>
 </dict>
 </plist>


### PR DESCRIPTION
## 内容

accompanist-permissionsを利用して位置情報のpermissionをリクエストできるよう変更。  
Secondタブに切り替えた時にリクエストするよう仮実装。  
Composable経由でpermissionをリクエストしているのは気に入らないが、リクエストダイアログもViewとして捉えれば極端に違和感はないと考えた。

### スクショ

|Android|iOS|
| :---|:---|
|<img width =300 src=https://github.com/kyam3235/WeatherReport/assets/11660859/033bc8ed-d0bd-4061-8acd-a8b50900b011 />|<img width=300 src=https://github.com/kyam3235/WeatherReport/assets/11660859/d9fad664-34f8-4c36-b527-429b25dd185c />|

## 参考

- https://www.jetbrains.com/help/kotlin-multiplatform-dev/multiplatform-samples.html
- https://github.com/JetBrains/compose-multiplatform/tree/master/examples/imageviewer
- #19 
- https://google.github.io/accompanist/permissions/

## 備考

- [moko-permissions](https://github.com/icerockdev/moko-permissions)も検討したがPermissionControllerをInjectする方法がわからず断念
- ライブラリを利用しない方法も検討したがあまりにもめんどくさすぎるので断念。コードも煩雑になり実用性はないと判断
  - #19 